### PR TITLE
[fix] for update of final cut pro trial

### DIFF
--- a/src-tauri/src/core.rs
+++ b/src-tauri/src/core.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use tauri::api::path::home_dir;
 
-
 fn get_logic_path() -> Result<PathBuf, String> {
     let mut path = home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
     path.push("Library/Application Support/.lpxuserdata");
@@ -12,13 +11,17 @@ fn get_logic_path() -> Result<PathBuf, String> {
 
 fn get_finalcut_path() -> Result<PathBuf, String> {
     let mut path = home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
-    path.push("Library/Application Support/.ffuserdata");
+
+    // for updated version of FinalCutTrial.
+    // older path is `~/Library/Application Support/.ffuserdata`
+    path.push(
+        "Library/Containers/com.apple.FinalCutTrial/Data/Library/Application Support/.ffuserdata",
+    );
     Ok(path)
 }
 
 #[tauri::command]
 pub fn reset_trial_data() -> Result<(), String> {
-
     let logic_pro_path = get_logic_path()?;
     let final_cut_path = get_finalcut_path()?;
 
@@ -36,22 +39,29 @@ pub fn reset_trial_data() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn reset_trial_data_watcher( app: tauri::AppHandle, activate: bool) {
-
-    app.tray_handle().get_item("automate").set_selected(activate).unwrap();
+pub fn reset_trial_data_watcher(app: tauri::AppHandle, activate: bool) {
+    app.tray_handle()
+        .get_item("automate")
+        .set_selected(activate)
+        .unwrap();
     println!("tray item automate changed to {}", activate);
-
 }
 
 #[tauri::command]
-pub async fn backend_i18n( app_handle: tauri::AppHandle, lang_obj: serde_json::Value, lang_id: String) -> String {
-
+pub async fn backend_i18n(
+    app_handle: tauri::AppHandle,
+    lang_obj: serde_json::Value,
+    lang_id: String,
+) -> String {
     let tray_handle = app_handle.tray_handle();
 
     lang_obj.as_object().map(|obj| {
         for (tray_key, title) in obj {
             if let Some(title_str) = title.as_str() {
-                tray_handle.get_item(tray_key).set_title(title_str).expect("error");
+                tray_handle
+                    .get_item(tray_key)
+                    .set_title(title_str)
+                    .expect("error");
             } else {
                 println!("Didn't match a value for tray.{} in locale file", tray_key);
             }


### PR DESCRIPTION
today i install the new version of final cut trial and find path of `.ffuserdata` changed. New path is 
```
~/Library/Containers/com.apple.FinalCutTrial/Data/Library/Application Support/.ffuserdata
```
